### PR TITLE
Unpin typescript version

### DIFF
--- a/src/create.ts
+++ b/src/create.ts
@@ -25,7 +25,7 @@ const DEPENDENCIES = [
   "prettier",
   "react-dom",
   "react",
-  "typescript@4.6.x",
+  "typescript",
 ];
 
 export interface CreateOptions {


### PR DESCRIPTION
**Public-Facing Changes**
This unpins the typescript version from generated extensions.


**Description**
The fix from https://github.com/foxglove/create-foxglove-extension/pull/43 is no longer needed so we can just install the latest version of all our dependencies in newly created extensions.

<!-- link relevant GitHub issues -->
