### PR TITLE
Save and restore image panel example state

### DIFF
--- a/examples/custom-image-extension/package.json
+++ b/examples/custom-image-extension/package.json
@@ -3,7 +3,7 @@
   "displayName": "Foxglove Example Custom Image Extension Panel",
   "description": "",
   "publisher": "Foxglove",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "license": "MIT",
   "main": "./dist/extension.js",
   "scripts": {


### PR DESCRIPTION
**Public-Facing Changes**
This adds code in the image panel example to save and restore panel state to the layout.

<!-- link relevant GitHub issues -->
