### PR TITLE
add some dev commands to template README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Introduction
 
-[Foxglove Studio](https://github.com/foxglove/studio) allows developers to create extensions, or custom code that is loaded and executed inside the Foxglove Studio application. This can be used to add custom panels, and in the future it will support custom file formats or data sources and more. Extensions are authored in TypeScript using the `@foxglove/studio` SDK.
+[Foxglove Studio](https://github.com/foxglove/studio) allows developers to create extensions, or custom code that is loaded and executed inside the Foxglove Studio application. This can be used to add custom panels. Extensions are authored in TypeScript using the `@foxglove/studio` SDK.
 
 ## Creating Your First Extension
 
@@ -56,9 +56,9 @@ yarn package
 
 This will produce a _.foxe_ file such as `helloworld-0.0.0.foxe`. This is essentially a ZIP archive containing your extension manifest and compiled code that can be opened by the Foxglove Studio application, which will unpack it and install it to the `~/.foxglove-studio/extensions` folder. Stay tuned for future instructions on how to publish Foxglove Studio extensions to a registry so other users can easily search for and install your extension.
 
-## Example Panels
+## Examples
 
-You can find examples of different kinds of extension panels in the `./examples` directory.
+You can find examples of different kinds of extensions in the `./examples` directory.
 
 ## Stay in touch
 

--- a/template/README.md
+++ b/template/README.md
@@ -6,18 +6,18 @@
 
 ## Develop
 
-Extension development uses the `yarn` package manager to install development dependencies and run build scripts.
+Extension development uses the `npm` package manager to install development dependencies and run build scripts.
 
-To install extension dependencies, run `yarn` from the root of the extension package.
+To install extension dependencies, run `npm` from the root of the extension package.
 
 ```sh
-yarn
+npm install
 ```
 
 To build and install the extension into your local Foxglove Studio desktop app, run:
 
 ```sh
-yarn local-install
+npm run local-install
 ```
 
 Open the `Foxglove Studio` desktop (or `ctrl-R` to refresh if it is already open). Your extension is installed and available within the app.
@@ -29,7 +29,7 @@ Extensions are packaged into `.foxe` files. These files contain the metadata (pa
 Before packaging, make sure to set `name`, `publisher`, `version`, and `description` fields in _package.json_. When ready to distribute the extension, run:
 
 ```sh
-yarn package
+npm run package
 ```
 
 This command will package the extension into a `.foxe` file in the local directory.

--- a/template/README.md
+++ b/template/README.md
@@ -1,3 +1,41 @@
 # ${NAME}
 
 ## _A Foxglove Studio Extension_
+
+[Foxglove Studio](https://github.com/foxglove/studio) allows developers to create extensions, or custom code that is loaded and executed inside the Foxglove Studio application. This can be used to add custom panels. Extensions are authored in TypeScript using the `@foxglove/studio` SDK.
+
+## Develop
+
+Extension development uses the `yarn` package manager to install development dependencies and run build scripts.
+
+To install extension dependencies, run `yarn` from the root of the extension package.
+
+```sh
+yarn
+```
+
+To build and install the extension into your local Foxglove Studio desktop app, run:
+
+```sh
+yarn local-install
+```
+
+Open the `Foxglove Studio` desktop (or `ctrl-R` to refresh if it is already open). Your extension is installed and available within the app.
+
+## Package
+
+Extensions are packaged into `.foxe` files. These files contain the metadata (package.json) and the build code for the extension.
+
+Before packaging, make sure to set `name`, `publisher`, `version`, and `description` fields in _package.json_. When ready to distribute the extension, run:
+
+```sh
+yarn package
+```
+
+This command will package the extension into a `.foxe` file in the local directory.
+
+## Publish
+
+You can publish the extension for the public marketplace or privately for your organization.
+
+See documentation here: https://foxglove.dev/docs/studio/extensions/publish#packaging-your-extension


### PR DESCRIPTION
After running `npm init foxglove-extension` I opened my code repo and naturally gravitated to the `README.md` file to learn what I should do to build and run my extension. Our default README.md template didn't have an content so I added some contnet I found useful for local development and packaging.