### PR TITLE
Install extension also to `$HOME/snap/foxglove-studio/current` if present

### DIFF
--- a/src/log.ts
+++ b/src/log.ts
@@ -2,10 +2,6 @@ export function info(message: unknown, ...args: unknown[]): void {
   console.log(message, ...args);
 }
 
-export function warn(message: unknown, ...args: unknown[]): void {
-  console.warn(message, ...args);
-}
-
 export function fatal(message: unknown, ...args: unknown[]): void {
   console.error(message, ...args);
   process.exit(1);

--- a/src/log.ts
+++ b/src/log.ts
@@ -2,6 +2,10 @@ export function info(message: unknown, ...args: unknown[]): void {
   console.log(message, ...args);
 }
 
+export function warn(message: unknown, ...args: unknown[]): void {
+  console.warn(message, ...args);
+}
+
 export function fatal(message: unknown, ...args: unknown[]): void {
   console.error(message, ...args);
   process.exit(1);

--- a/src/package.ts
+++ b/src/package.ts
@@ -11,7 +11,7 @@ import rimraf from "rimraf";
 import { promisify } from "util";
 
 import { getPackageDirname, getPackageId, parsePackageName } from "./extensions";
-import { info, warn } from "./log";
+import { info } from "./log";
 
 const cpR = promisify(ncp);
 
@@ -287,8 +287,7 @@ async function install(
       if (!(await isDirectory(dir))) {
         continue;
       }
-    } catch (err) {
-      warn(`Skipping installation into ${dir}: Directory not found`);
+    } catch (_err) {
       continue;
     }
 

--- a/src/package.ts
+++ b/src/package.ts
@@ -1,7 +1,7 @@
 import { spawn } from "child_process";
 import { createHash } from "crypto";
 import { createReadStream, createWriteStream } from "fs";
-import { mkdir, readFile, readdir, stat, realpath } from "fs/promises";
+import { mkdir, readFile, readdir, stat } from "fs/promises";
 import JSZip from "jszip";
 import ncp from "ncp";
 import fetch from "node-fetch";
@@ -11,7 +11,7 @@ import rimraf from "rimraf";
 import { promisify } from "util";
 
 import { getPackageDirname, getPackageId, parsePackageName } from "./extensions";
-import { info } from "./log";
+import { info, warn } from "./log";
 
 const cpR = promisify(ncp);
 
@@ -280,10 +280,15 @@ async function install(
 
   const dirName = getPackageDirname(pkg);
   const homeDir = homedir();
-  const snapDataDir = await realpath(join(homedir(), "snap", "foxglove-studio", "current"));
+  const snapDataDir = join(homedir(), "snap", "foxglove-studio", "current");
 
   for (const dir of [homeDir, snapDataDir]) {
-    if (!(await isDirectory(dir))) {
+    try {
+      if (!(await isDirectory(dir))) {
+        continue;
+      }
+    } catch (err) {
+      warn(`Skipping installation into ${dir}: Directory not found`);
       continue;
     }
 

--- a/src/package.ts
+++ b/src/package.ts
@@ -283,7 +283,7 @@ async function install(
   const snapDataDir = await realpath(join(homedir(), "snap", "foxglove-studio", "current"));
 
   for (const dir of [homeDir, snapDataDir]) {
-    if (!isDirectory(dir)) {
+    if (!(await isDirectory(dir))) {
       continue;
     }
 


### PR DESCRIPTION
**Public-Facing Changes**
- Installs the extension also to `$HOME/snap/foxglove-studio/current` (if present)


**Description**
If Studio is run from a snap package, `$HOME/.foxglove-studio` resolves to `$HOME/snap/foxglove-studio/current/.foxglove-studio`. This PR changes the install script, such that extensions are installed also in the snap data directory if it is present

Example output:

```
Build complete
Copying files to /home/achim/.foxglove-studio/extensions/unknown.achim-0.0.0
  - CHANGELOG.md -> /home/achim/.foxglove-studio/extensions/unknown.achim-0.0.0/CHANGELOG.md
  - ...
Skipping installation into /home/achim/snap/foxglove-studio/current: Directory not found
```

```
Build complete
Copying files to /home/achim/.foxglove-studio/extensions/unknown.achim-0.0.0
  - CHANGELOG.md -> /home/achim/.foxglove-studio/extensions/unknown.achim-0.0.0/CHANGELOG.md
  - ...
Copying files to /home/achim/snap/foxglove-studio/current/.foxglove-studio/extensions/unknown.achim-0.0.0
  - CHANGELOG.md -> /home/achim/snap/foxglove-studio/current/.foxglove-studio/extensions/unknown.achim-0.0.0/CHANGELOG.md
  - ...
```
