### PR TITLE
Update examples to unmount react component on panel teardown

### DIFF
--- a/examples/call-service-panel-example/package.json
+++ b/examples/call-service-panel-example/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "@foxglove/eslint-plugin": "0.21.0",
-    "@foxglove/studio": "1.39.1",
+    "@foxglove/studio": "1.43.0",
     "@types/react": "18.0.27",
     "@types/react-dom": "18.0.10",
     "@typescript-eslint/eslint-plugin": "5.50.0",

--- a/examples/call-service-panel-example/src/CallServicePanel.tsx
+++ b/examples/call-service-panel-example/src/CallServicePanel.tsx
@@ -1,4 +1,4 @@
-import { PanelExtensionContext, RenderState } from "@foxglove/studio";
+import { PanelExtensionContext, ExtensionPanelRegistration, RenderState } from "@foxglove/studio";
 import { useCallback, useEffect, useLayoutEffect, useState } from "react";
 import ReactDOM from "react-dom";
 import ReactJson from "react-json-view";
@@ -107,6 +107,11 @@ function CallServicePanel({ context }: { context: PanelExtensionContext }): JSX.
   );
 }
 
-export function initCallServicePanel(context: PanelExtensionContext): void {
+export const initCallServicePanel: ExtensionPanelRegistration["initPanel"] = (context) => {
   ReactDOM.render(<CallServicePanel context={context} />, context.panelElement);
-}
+
+  // Return a function to run when the panel is removed
+  return () => {
+    ReactDOM.unmountComponentAtNode(context.panelElement);
+  };
+};

--- a/examples/custom-image-extension/package.json
+++ b/examples/custom-image-extension/package.json
@@ -18,7 +18,7 @@
   "devDependencies": {
     "@foxglove/eslint-plugin": "0.20.0",
     "@foxglove/schemas": "0.2.0",
-    "@foxglove/studio": "1.17.1",
+    "@foxglove/studio": "1.43.0",
     "@types/react": "18.0.15",
     "@types/react-dom": "18.0.6",
     "@typescript-eslint/eslint-plugin": "5.30.6",

--- a/examples/custom-image-extension/src/ExamplePanel.tsx
+++ b/examples/custom-image-extension/src/ExamplePanel.tsx
@@ -1,5 +1,11 @@
 import { CompressedImage } from "@foxglove/schemas/schemas/typescript";
-import { PanelExtensionContext, RenderState, Topic, MessageEvent } from "@foxglove/studio";
+import {
+  PanelExtensionContext,
+  ExtensionPanelRegistration,
+  RenderState,
+  Topic,
+  MessageEvent,
+} from "@foxglove/studio";
 import { useLayoutEffect, useEffect, useState, useRef, useMemo } from "react";
 import ReactDOM from "react-dom";
 
@@ -124,6 +130,11 @@ function ExamplePanel({ context }: { context: PanelExtensionContext }): JSX.Elem
   );
 }
 
-export function initExamplePanel(context: PanelExtensionContext): void {
+export const initExamplePanel: ExtensionPanelRegistration["initPanel"] = (context) => {
   ReactDOM.render(<ExamplePanel context={context} />, context.panelElement);
-}
+
+  // Return a function to run when the panel is removed
+  return () => {
+    ReactDOM.unmountComponentAtNode(context.panelElement);
+  };
+};

--- a/examples/extension-demo/package.json
+++ b/examples/extension-demo/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "foxglove-example-custom-image-extension-panel",
+  "name": "foxglove-extension-demo",
   "displayName": "Foxglove Example Custom Image Extension Panel",
   "description": "",
   "publisher": "Foxglove",

--- a/examples/extension-demo/package.json
+++ b/examples/extension-demo/package.json
@@ -18,7 +18,7 @@
   "devDependencies": {
     "@foxglove/eslint-plugin": "0.20.0",
     "@foxglove/schemas": "0.2.0",
-    "@foxglove/studio": "1.17.1",
+    "@foxglove/studio": "1.43.0",
     "@types/react": "18.0.15",
     "@types/react-dom": "18.0.6",
     "@typescript-eslint/eslint-plugin": "5.30.6",

--- a/examples/extension-demo/src/ExamplePanel.tsx
+++ b/examples/extension-demo/src/ExamplePanel.tsx
@@ -1,5 +1,11 @@
 import { CompressedImage } from "@foxglove/schemas/schemas/typescript";
-import { PanelExtensionContext, RenderState, Topic, MessageEvent } from "@foxglove/studio";
+import {
+  ExtensionPanelRegistration,
+  PanelExtensionContext,
+  RenderState,
+  Topic,
+  MessageEvent,
+} from "@foxglove/studio";
 import { useLayoutEffect, useEffect, useState, useRef, useMemo } from "react";
 import ReactDOM from "react-dom";
 
@@ -115,6 +121,11 @@ function ExamplePanel({ context }: { context: PanelExtensionContext }): JSX.Elem
   );
 }
 
-export function initExamplePanel(context: PanelExtensionContext): void {
+export const initExamplePanel: ExtensionPanelRegistration["initPanel"] = (context) => {
   ReactDOM.render(<ExamplePanel context={context} />, context.panelElement);
-}
+
+  // Return a function to run when the panel is removed
+  return () => {
+    ReactDOM.unmountComponentAtNode(context.panelElement);
+  };
+};

--- a/examples/message-converter/package.json
+++ b/examples/message-converter/package.json
@@ -18,7 +18,7 @@
   "devDependencies": {
     "@foxglove/eslint-plugin": "0.20.0",
     "@foxglove/schemas": "0.7.2",
-    "@foxglove/studio": "1.33.0",
+    "@foxglove/studio": "1.43.0",
     "@types/react": "18.0.25",
     "@types/react-dom": "18.0.9",
     "@typescript-eslint/eslint-plugin": "5.45.0",

--- a/examples/monaco-editor-example/package.json
+++ b/examples/monaco-editor-example/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "@foxglove/eslint-plugin": "0.20.0",
-    "@foxglove/studio": "1.21.0",
+    "@foxglove/studio": "1.43.0",
     "@monaco-editor/react": "4.4.5",
     "@types/react": "18.0.17",
     "@types/react-dom": "18.0.6",

--- a/examples/monaco-editor-example/src/ExamplePanel.tsx
+++ b/examples/monaco-editor-example/src/ExamplePanel.tsx
@@ -1,4 +1,10 @@
-import { PanelExtensionContext, RenderState, Topic, MessageEvent } from "@foxglove/studio";
+import {
+  PanelExtensionContext,
+  ExtensionPanelRegistration,
+  RenderState,
+  Topic,
+  MessageEvent,
+} from "@foxglove/studio";
 import { useLayoutEffect, useEffect, useState } from "react";
 import ReactDOM from "react-dom";
 import { Editor } from "./Editor";
@@ -61,6 +67,11 @@ function ExamplePanel({ context }: { context: PanelExtensionContext }): JSX.Elem
   );
 }
 
-export function initExamplePanel(context: PanelExtensionContext) {
+export const initExamplePanel: ExtensionPanelRegistration["initPanel"] = (context) => {
   ReactDOM.render(<ExamplePanel context={context} />, context.panelElement);
-}
+
+  // Return a function to run when the panel is removed
+  return () => {
+    ReactDOM.unmountComponentAtNode(context.panelElement);
+  };
+};

--- a/examples/panel-settings/package.json
+++ b/examples/panel-settings/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "@foxglove/eslint-plugin": "0.20.0",
-    "@foxglove/studio": "1.17.1",
+    "@foxglove/studio": "1.43.0",
     "@types/lodash": "4.14.182",
     "@types/react": "18.0.15",
     "@types/react-dom": "18.0.6",

--- a/examples/panel-settings/src/ExamplePanel.tsx
+++ b/examples/panel-settings/src/ExamplePanel.tsx
@@ -1,5 +1,6 @@
 import {
   PanelExtensionContext,
+  ExtensionPanelRegistration,
   RenderState,
   Topic,
   MessageEvent,
@@ -225,6 +226,11 @@ function ExamplePanel({ context }: { context: PanelExtensionContext }): JSX.Elem
   );
 }
 
-export function initExamplePanel(context: PanelExtensionContext): void {
+export const initExamplePanel: ExtensionPanelRegistration["initPanel"] = (context) => {
   ReactDOM.render(<ExamplePanel context={context} />, context.panelElement);
-}
+
+  // Return a function to run when the panel is removed
+  return () => {
+    ReactDOM.unmountComponentAtNode(context.panelElement);
+  };
+};

--- a/examples/simple-3d-extension/package.json
+++ b/examples/simple-3d-extension/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "@foxglove/eslint-plugin": "0.20.0",
-    "@foxglove/studio": "1.17.1",
+    "@foxglove/studio": "1.43.0",
     "@types/three": "0.141.0",
     "@typescript-eslint/eslint-plugin": "5.30.6",
     "@typescript-eslint/parser": "5.30.6",

--- a/examples/simple-3d-extension/src/ThreeDeePanel.tsx
+++ b/examples/simple-3d-extension/src/ThreeDeePanel.tsx
@@ -1,4 +1,4 @@
-import { PanelExtensionContext, RenderState } from "@foxglove/studio";
+import { RenderState, ExtensionPanelRegistration } from "@foxglove/studio";
 import {
   AmbientLight,
   Mesh,
@@ -12,7 +12,7 @@ import {
 import { OrbitControls } from "three/examples/jsm/controls/OrbitControls";
 
 // Sets up our panel and our context onRender function.
-function setup3dPanel(context: PanelExtensionContext) {
+export const initThreeDeePanel: ExtensionPanelRegistration["initPanel"] = (context) => {
   // Create core scene components.
   const renderer = new WebGLRenderer();
   renderer.setClearColor(0x111111, 1);
@@ -65,8 +65,9 @@ function setup3dPanel(context: PanelExtensionContext) {
   }
 
   animate();
-}
 
-export function initThreeDeePanel(context: PanelExtensionContext): void {
-  setup3dPanel(context);
-}
+  // Return a cleanup function to run when the panel is removed
+  return () => {
+    renderer.dispose();
+  };
+};

--- a/examples/webworker/package.json
+++ b/examples/webworker/package.json
@@ -18,7 +18,7 @@
   "devDependencies": {
     "@foxglove/eslint-plugin": "0.20.0",
     "@foxglove/schemas": "0.2.0",
-    "@foxglove/studio": "1.17.1",
+    "@foxglove/studio": "1.43.0",
     "@types/react": "18.0.15",
     "@types/react-dom": "18.0.6",
     "@typescript-eslint/eslint-plugin": "5.30.6",

--- a/examples/webworker/src/index.ts
+++ b/examples/webworker/src/index.ts
@@ -1,15 +1,20 @@
-import { ExtensionContext, PanelExtensionContext } from "@foxglove/studio";
+import { ExtensionContext, ExtensionPanelRegistration } from "@foxglove/studio";
 
 import PanelWorker from "./Panel.worker";
 
-export function initPanel(context: PanelExtensionContext): void {
+const initPanel: ExtensionPanelRegistration["initPanel"] = (context) => {
   const result = new PanelWorker();
   result.addEventListener("message", (msg) => {
     const msgDiv = document.createElement("div");
     msgDiv.innerText = msg.data;
     context.panelElement.appendChild(msgDiv);
   });
-}
+
+  // Return a cleanup function to run when the panel is removed
+  return () => {
+    result.terminate();
+  };
+};
 
 export function activate(extensionContext: ExtensionContext): void {
   extensionContext.registerPanel({

--- a/examples/webworker/yarn.lock
+++ b/examples/webworker/yarn.lock
@@ -48,10 +48,10 @@
     "@foxglove/rosmsg-msgs-common" "^1.0.4"
     tslib "^2"
 
-"@foxglove/studio@1.17.1":
-  version "1.17.1"
-  resolved "https://registry.yarnpkg.com/@foxglove/studio/-/studio-1.17.1.tgz#b3ca38e900c4bfb9a71fc4735f97e28df0e57096"
-  integrity sha512-eFiHBustXeEkflecDQkR/sSl5fE5ugNO2Ukc/pQiL6A/h2UHg23SEN7Rm6F7GTgPri9CZpw6jcg5kZiLyL6cZg==
+"@foxglove/studio@1.43.0":
+  version "1.43.0"
+  resolved "https://registry.yarnpkg.com/@foxglove/studio/-/studio-1.43.0.tgz#9ba2a3a8109cf66badb03abfd79871f5b23be6f9"
+  integrity sha512-wPr/HLL1sstazEJSt8hI1nXg5PC8RX05TXm86RrSnstODeXQu+lLVOwupLzTDam+SO5BHysXegFOPSM3j98i1w==
 
 "@humanwhocodes/config-array@^0.9.2":
   version "0.9.5"

--- a/template/src/ExamplePanel.tsx
+++ b/template/src/ExamplePanel.tsx
@@ -1,4 +1,10 @@
-import { PanelExtensionContext, RenderState, Topic, MessageEvent } from "@foxglove/studio";
+import {
+  PanelExtensionContext,
+  ExtensionPanelRegistration,
+  RenderState,
+  Topic,
+  MessageEvent,
+} from "@foxglove/studio";
 import { useLayoutEffect, useEffect, useState } from "react";
 import ReactDOM from "react-dom";
 
@@ -76,6 +82,11 @@ function ExamplePanel({ context }: { context: PanelExtensionContext }): JSX.Elem
   );
 }
 
-export function initExamplePanel(context: PanelExtensionContext): void {
+export const initExamplePanel: ExtensionPanelRegistration["initPanel"] = (context) => {
   ReactDOM.render(<ExamplePanel context={context} />, context.panelElement);
-}
+
+  // Return a function to run when the panel is removed
+  return () => {
+    ReactDOM.unmountComponentAtNode(context.panelElement);
+  };
+};


### PR DESCRIPTION
The `initPanel` function can return a cleanup function that is run when the panel is torn down (aka removed). A common use of this function is to cleanup event handlers or unmount components to free up resources. We updated Studio panels to return a cleanup function.

This change updates the examples to return a cleanup function so extension authors benefit from having a way to cleanup resources and unmount components.