### PR TITLE
Update examples and template to use object subscribe syntax

### DIFF
--- a/examples/custom-image-extension/src/ExamplePanel.tsx
+++ b/examples/custom-image-extension/src/ExamplePanel.tsx
@@ -57,7 +57,7 @@ function ExamplePanel({ context }: { context: PanelExtensionContext }): JSX.Elem
 
     if (state.topic) {
       // Subscribe to the new image topic when a new topic is chosen.
-      context.subscribe([state.topic]);
+      context.subscribe([{ topic: state.topic }]);
     }
   }, [context, state.topic]);
 

--- a/examples/extension-demo/src/ExamplePanel.tsx
+++ b/examples/extension-demo/src/ExamplePanel.tsx
@@ -53,7 +53,7 @@ function ExamplePanel({ context }: { context: PanelExtensionContext }): JSX.Elem
 
     if (state.topic) {
       // Subscribe to the new image topic when a new topic is chosen.
-      context.subscribe([state.topic]);
+      context.subscribe([{ topic: state.topic }]);
     }
   }, [context, state.topic]);
 

--- a/examples/monaco-editor-example/src/ExamplePanel.tsx
+++ b/examples/monaco-editor-example/src/ExamplePanel.tsx
@@ -46,7 +46,7 @@ function ExamplePanel({ context }: { context: PanelExtensionContext }): JSX.Elem
 
     // subscribe to some topics, you could do this within other effects, based on input fields, etc
     // Once you subscribe to topics, currentFrame will contain message events from those topics (assuming there are messages).
-    context.subscribe(["/some/topic"]);
+    context.subscribe([{ topic: "/some/topic" }]);
   }, []);
 
   // invoke the done callback once the render is complete

--- a/examples/panel-settings/src/ExamplePanel.tsx
+++ b/examples/panel-settings/src/ExamplePanel.tsx
@@ -96,7 +96,7 @@ function ExamplePanel({ context }: { context: PanelExtensionContext }): JSX.Elem
 
         // If the topic was changed update our subscriptions.
         if (path[1] === "topic") {
-          context.subscribe([value as string]);
+          context.subscribe([{ topic: value as string }]);
         }
       }
     },
@@ -196,7 +196,7 @@ function ExamplePanel({ context }: { context: PanelExtensionContext }): JSX.Elem
 
     // Subscribe to our initial topic.
     if (state.data.topic) {
-      context.subscribe([state.data.topic]);
+      context.subscribe([{ topic: state.data.topic }]);
     }
   }, [context, state.data.topic]);
 

--- a/template/src/ExamplePanel.tsx
+++ b/template/src/ExamplePanel.tsx
@@ -45,7 +45,7 @@ function ExamplePanel({ context }: { context: PanelExtensionContext }): JSX.Elem
 
     // subscribe to some topics, you could do this within other effects, based on input fields, etc
     // Once you subscribe to topics, currentFrame will contain message events from those topics (assuming there are messages).
-    context.subscribe(["/some/topic"]);
+    context.subscribe([{ topic: "/some/topic" }]);
   }, [context]);
 
   // invoke the done callback once the render is complete


### PR DESCRIPTION
The string array form of subscribe has the legacy behavior of subscribing with preloading. For most custom panels this is not necessary and results in requesting more data. This change updates the template and examples to use the new subscribe api which gives the user the option of which topics are preloaded.