### PR TITLE
Update template README to use yarn instead of npm

### DIFF
--- a/template/README.md
+++ b/template/README.md
@@ -6,18 +6,18 @@
 
 ## Develop
 
-Extension development uses the `npm` package manager to install development dependencies and run build scripts.
+Extension development uses the `yarn` package manager to install development dependencies and run build scripts.
 
-To install extension dependencies, run `npm` from the root of the extension package.
+To install extension dependencies, run `yarn` from the root of the extension package.
 
 ```sh
-npm install
+yarn install
 ```
 
 To build and install the extension into your local Foxglove Studio desktop app, run:
 
 ```sh
-npm run local-install
+yarn run local-install
 ```
 
 Open the `Foxglove Studio` desktop (or `ctrl-R` to refresh if it is already open). Your extension is installed and available within the app.
@@ -29,7 +29,7 @@ Extensions are packaged into `.foxe` files. These files contain the metadata (pa
 Before packaging, make sure to set `name`, `publisher`, `version`, and `description` fields in _package.json_. When ready to distribute the extension, run:
 
 ```sh
-npm run package
+yarn run package
 ```
 
 This command will package the extension into a `.foxe` file in the local directory.


### PR DESCRIPTION
### Public-Facing Changes
Update template README to use yarn instead of npm.
<!-- describe any changes to the public interface or APIs, or write "None" -->

### Description
Update template README to use yarn instead of npm.
<!-- describe what has changed, and motivation behind those changes -->

<!-- Link relevant Github issues. Use `Fixes #1234` to auto-close the issue after merging. -->
