### PR TITLE
Don't generated unneeded .d.ts files in extension builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-foxglove-extension",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "publisher": "foxglove",
   "description": "Create and package Foxglove Studio extensions",
   "license": "MIT",

--- a/src/create.test.ts
+++ b/src/create.test.ts
@@ -48,5 +48,11 @@ describe("createCommand", () => {
 
     // make sure the skeleton package is buildable and packagable
     await packageCommand({ cwd: destDir });
+
+    // make sure we don't generate unneeded .d.ts files
+    const builtContents = await readdir(path.join(destDir, "dist"), { withFileTypes: true });
+    const builtFiles = builtContents.filter((entry) => entry.isFile()).map((entry) => entry.name);
+    expect(builtFiles).not.toContain("ExamplePanel.d.ts");
+    expect(builtFiles).not.toContain("index.d.ts");
   });
 });

--- a/src/create.test.ts
+++ b/src/create.test.ts
@@ -52,7 +52,6 @@ describe("createCommand", () => {
     // make sure we don't generate unneeded .d.ts files
     const builtContents = await readdir(path.join(destDir, "dist"), { withFileTypes: true });
     const builtFiles = builtContents.filter((entry) => entry.isFile()).map((entry) => entry.name);
-    expect(builtFiles).not.toContain("ExamplePanel.d.ts");
-    expect(builtFiles).not.toContain("index.d.ts");
+    expect(builtFiles.some((name) => name.endsWith(".d.ts"))).toBe(false);
   });
 });

--- a/template/tsconfig.json
+++ b/template/tsconfig.json
@@ -7,7 +7,7 @@
     "outDir": "./dist",
     "lib": ["dom"],
 
-    // These two settings prevent typescript from emitting a .d.ts file we don't need in
+    // These two settings prevent typescript from emitting .d.ts files we don't need in
     // the compiled extension.
     "composite": false,
     "declaration": false,

--- a/template/tsconfig.json
+++ b/template/tsconfig.json
@@ -7,6 +7,11 @@
     "outDir": "./dist",
     "lib": ["dom"],
 
+    // These two settings prevent typescript from emitting a .d.ts file we don't need in
+    // the compiled extension.
+    "composite": false,
+    "declaration": false,
+
     // Additional TypeScript error reporting checks are enabled by default to improve code quality.
     // Enable/disable these checks as necessary to suit your coding preferences or work with
     // existing code


### PR DESCRIPTION
### Public-Facing Changes
None

### Description
Don't generate unneeded typescript .d.ts definition files in extension packages.
<!-- describe what has changed, and motivation behind those changes -->

<!-- Link relevant Github issues. Use `Fixes #1234` to auto-close the issue after merging. -->
Fixes https://github.com/foxglove/create-foxglove-extension/issues/101
