### PR TITLE
Fix prettier dependency in new extensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-foxglove-extension",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "publisher": "foxglove",
   "description": "Create and package Foxglove Studio extensions",
   "license": "MIT",

--- a/src/create.ts
+++ b/src/create.ts
@@ -18,7 +18,7 @@ const DEPENDENCIES = [
   "eslint-config-prettier",
   "eslint-plugin-import",
   "eslint-plugin-jest",
-  "eslint-plugin-prettier",
+  "eslint-plugin-prettier@4",
   "eslint-plugin-react-hooks",
   "eslint-plugin-react",
   "eslint-plugin-filenames",


### PR DESCRIPTION
### Public-Facing Changes
Fix prettier dependency in newly created extensions, allowing npm install to succeed.

### Description
Looks like the prettier dependency in @foxglove/eslint-plugin can't be resolved with the latest version of `eslint-plugin-prettier` without a more specific version dependency.

Note that even with this the install prints a somewhat scary warning:
```shell
npm WARN ERESOLVE overriding peer dependency
npm WARN While resolving: newfoo@0.0.0
npm WARN Found: prettier@2.8.8
npm WARN node_modules/prettier
npm WARN   dev prettier@"*" from the root project
npm WARN   2 more (@foxglove/eslint-plugin, eslint-plugin-prettier)
npm WARN 
npm WARN Could not resolve dependency:
npm WARN peer prettier@"^2" from @foxglove/eslint-plugin@0.22.1
npm WARN node_modules/@foxglove/eslint-plugin
npm WARN   dev @foxglove/eslint-plugin@"*" from the root project
```

So we may want to fix the prettier dependency in `@foxglove/eslint-plugin` as well/instead.

Alternative fix: https://github.com/foxglove/eslint-plugin/pull/47
