### PR TITLE
Use special label & visibility properties in panel settings example

### DIFF
--- a/examples/panel-settings/package.json
+++ b/examples/panel-settings/package.json
@@ -4,7 +4,7 @@
   "description": "This is an example of the use of the settings api in an extension panel.",
   "publisher": "foxglove",
   "homepage": "",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "license": "UNLICENSED",
   "main": "./dist/extension.js",
   "keywords": [],


### PR DESCRIPTION
### Public-Facing Changes
Use special label & visibility properties in the panel settings example to illustrate the use of these fields.

### Description
Update the panel settings example to show panel authors how to take advantage of the label and visibility properties in settings editor nodes.

<!-- describe what has changed, and motivation behind those changes -->

<!-- Link relevant Github issues. Use `Fixes #1234` to auto-close the issue after merging. -->
