### PR TITLE
Fix packaging on windows

### DIFF
--- a/src/package.test.ts
+++ b/src/package.test.ts
@@ -1,0 +1,59 @@
+import { mkdir, readFile, readdir, writeFile } from "fs/promises";
+import JSZip from "jszip";
+import * as path from "path";
+import { dirSync, setGracefulCleanup } from "tmp";
+
+import { packageCommand } from "./package";
+
+let tmpdir: string;
+
+jest.setTimeout(120 * 1000);
+
+jest.mock("./log.ts", () => ({
+  info: jest.fn(),
+  fatal: jest.fn((msg) => {
+    throw new Error(`fatal() called: ${String(msg)}`);
+  }),
+}));
+
+beforeAll(() => {
+  setGracefulCleanup();
+  tmpdir = dirSync({ unsafeCleanup: true }).name;
+});
+
+async function createFile(pathname: string, filename: string, contents = "") {
+  const fullpath = path.join(pathname, filename);
+  await writeFile(fullpath, contents);
+}
+
+describe("packageCommand", () => {
+  it("packages an extension", async () => {
+    // Actually creating a package is slow so we can fake it instead.
+    await createFile(
+      tmpdir,
+      "package.json",
+      JSON.stringify({
+        name: "test",
+        displayName: "test",
+        homepage: "http://example.com",
+        publisher: "test",
+        version: "1.0.0",
+        main: "./dist/extension.js",
+      }),
+    );
+    await createFile(tmpdir, "CHANGELOG.md");
+    await createFile(tmpdir, "README.md");
+    await mkdir(path.join(tmpdir, "dist"));
+    await createFile(path.join(tmpdir, "dist"), "extension.js");
+
+    await packageCommand({ cwd: tmpdir });
+    const contents = await readdir(tmpdir, { withFileTypes: true });
+
+    const bundle = contents.find((file) => file.name === "test.test-1.0.0.foxe");
+    const bundlePath = path.join(tmpdir, bundle!.name);
+    const bundleData = await readFile(bundlePath);
+    const archive = await JSZip.loadAsync(bundleData);
+    expect(archive.files["dist\\extension.js"]).not.toBeDefined();
+    expect(archive.files["dist/extension.js"]).toBeDefined();
+  });
+});

--- a/src/package.ts
+++ b/src/package.ts
@@ -353,7 +353,12 @@ async function addDirToZip(zip: JSZip, baseDir: string, dirname: string): Promis
 function addFileToZip(zip: JSZip, baseDir: string, filename: string) {
   const fullPath = join(baseDir, filename);
   info(`archiving ${fullPath}`);
-  zip.file<"stream">(filename, createReadStream(fullPath), { createFolders: true, date: MOD_DATE });
+  // zip file paths must use / as separator.
+  const zipFilename = filename.replace(/\\/g, "/");
+  zip.file<"stream">(zipFilename, createReadStream(fullPath), {
+    createFolders: true,
+    date: MOD_DATE,
+  });
 }
 
 function inDirectory(directory: string, pathname: string): boolean {


### PR DESCRIPTION
### Public-Facing Changes
Fix extension packaging on windows.

### Description
Make sure the .foxe zip file uses the standard `/` path separator and not a platform-specific separator.

From https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT:
```
  4.4.17.1 The name of the file, with optional relative path.
   The path stored MUST NOT contain a drive or
   device letter, or a leading slash.  All slashes
   MUST be forward slashes '/' as opposed to
   backwards slashes '\' for compatibility with Amiga
   and UNIX file systems etc.  If input came from standard
   input, there is no file name field. 
```
<!-- describe what has changed, and motivation behind those changes -->

<!-- Link relevant Github issues. Use `Fixes #1234` to auto-close the issue after merging. -->
FG-4744