### PR TITLE
Rename studio-extension-marketplace to extension-registry

### DIFF
--- a/src/bin/foxglove-extension.ts
+++ b/src/bin/foxglove-extension.ts
@@ -36,7 +36,7 @@ program
 program
   .command("publish")
   .description(
-    "Create an extensions.json entry for a released extension. This can be added to the https://github.com/foxglove/extension-marketplace repository",
+    "Create an extensions.json entry for a released extension. This can be added to the https://github.com/foxglove/extension-registry repository",
   )
   .option("--foxe <foxe>", "URL of the published .foxe file")
   .option("--cwd [cwd]", "Directory containing the extension package.json file")

--- a/src/bin/foxglove-extension.ts
+++ b/src/bin/foxglove-extension.ts
@@ -36,7 +36,7 @@ program
 program
   .command("publish")
   .description(
-    "Create an extensions.json entry for a released extension. This can be added to the https://github.com/foxglove/studio-extension-marketplace repository",
+    "Create an extensions.json entry for a released extension. This can be added to the https://github.com/foxglove/extension-marketplace repository",
   )
   .option("--foxe <foxe>", "URL of the published .foxe file")
   .option("--cwd [cwd]", "Directory containing the extension package.json file")


### PR DESCRIPTION
### Changelog
None

### Description

Updating references to studio-extension-marketplace which will soon be renamed to `extension-registry`. (This PR should not be merged until that rename is done)