### PR TITLE
Add provenance attestation when publishing to NPM

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -7,6 +7,11 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+
+    permissions:
+      # https://docs.npmjs.com/generating-provenance-statements#publishing-packages-with-provenance-via-github-actions
+      id-token: write
+
     steps:
       - uses: actions/checkout@v2.3.4
         with:
@@ -15,10 +20,10 @@ jobs:
       - name: Configure Node.js
         uses: actions/setup-node@v2.1.5
         with:
-          node-version: 16.x
+          node-version: 20.x
           registry-url: https://registry.npmjs.org/
 
       - run: yarn install --immutable
-      - run: npm publish --access public
+      - run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_PUBLISH_TOKEN}}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-foxglove-extension",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "publisher": "foxglove",
   "description": "Create and package Foxglove extensions",
   "license": "MIT",


### PR DESCRIPTION
### Changelog
None
### Docs

None

### Description

Forgot to do this before publishing 1.0.0 😅 

This adds a provenance attestation to the published package so consumers can verify that the package was built on GitHub Actions:
- https://github.blog/2023-04-19-introducing-npm-package-provenance/
- https://docs.npmjs.com/generating-provenance-statements#publishing-packages-with-provenance-via-github-actions

The package will appear like this on npm:

<img src="https://github.blog/wp-content/uploads/2023/04/npm-package-provenance-3.png?w=488&resize=488%2C394" width="250">
