### PR TITLE
Configure dependabot with directories

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directories:
+      - "/"
+      - "examples/*"
+    schedule:
+      interval: daily
+    # security updates do not obey this limit
+    open-pull-requests-limit: 0


### PR DESCRIPTION
### Changelog
None
### Docs
None
### Description

This adds a dependabot configuration file that specifies "directories" — a new [feature](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#directories) that _should_ group security updates for each of our examples:

> We recommend you use directories when you want to apply the exact same configuration to multiple directories or group dependency updates across multiple directories

Currently, when we make a security update to the primary source, dependabot will open a separate PR for each example to get on the latest version.

This does not enable additional updates beyond our existing security updates.