### PR TITLE
Enable compression for packaged zip (.foxe) files

### DIFF
--- a/src/package.ts
+++ b/src/package.ts
@@ -264,7 +264,7 @@ async function writeFoxe(baseDir: string, files: string[], outputFile: string): 
   info(`Writing archive to ${outputFile}`);
   return await new Promise((c, e) => {
     zip
-      .generateNodeStream({ type: "nodebuffer", streamFiles: true })
+      .generateNodeStream({ type: "nodebuffer", streamFiles: true, compression: "DEFLATE" })
       .pipe(createWriteStream(outputFile, { encoding: "binary" }) as NodeJS.WritableStream)
       .on("error", e)
       .on("finish", c);


### PR DESCRIPTION
### Changelog
- `.foxe` files are now compressed

### Description

JSZip default "compression" is STORE, you need to enable DEFLATE explicitly. See <https://stuk.github.io/jszip/documentation/api_jszip/generate_async.html#compression-and-compressionoptions-options>