### PR TITLE
remove retired ubuntu-20.04 in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,6 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-20.04
           - ubuntu-22.04
           - windows-2022
 


### PR DESCRIPTION
### Changelog

None

### Docs

None

### Description

PRs are failing because the ubuntu-20 image is retired. This PR removes the retired version.

Example failure:

![error](https://github.com/user-attachments/assets/0887d925-dc31-41ab-8140-7b113e8f8410)

https://github.com/foxglove/create-foxglove-extension/actions/runs/15888008404/job/44804593289?pr=171

If this PR is passing CI then the fix works.