### PR TITLE
Fix ndjson data loader example channel encodings

### DIFF
--- a/examples/ndjson-data-loader/package-lock.json
+++ b/examples/ndjson-data-loader/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "example-foxglove-ndjson-data-loader",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "example-foxglove-ndjson-data-loader",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "MIT",
       "devDependencies": {
         "@foxglove/eslint-plugin": "2.0.0",

--- a/examples/ndjson-data-loader/package.json
+++ b/examples/ndjson-data-loader/package.json
@@ -3,7 +3,7 @@
   "displayName": "Example Foxglove ndjson data loader",
   "description": "",
   "publisher": "Foxglove",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "license": "MIT",
   "main": "./dist/extension.js",
   "scripts": {

--- a/examples/ndjson-data-loader/rust/src/lib.rs
+++ b/examples/ndjson-data-loader/rust/src/lib.rs
@@ -84,15 +84,15 @@ impl DataLoader for NDJsonLoader {
             .end_time(seconds_to_nanos(end_seconds));
 
         let vec3_schema = init.add_encode::<Accelerometer>()?;
-        init.add_channel_with_id(ACC_CHANNEL_ID, "/accelerometer")
+        vec3_schema
+            .add_channel_with_id(ACC_CHANNEL_ID, "/accelerometer")
             .expect("channel should be free")
-            .schema(&vec3_schema)
             .message_count(accelerometer_count as u64);
 
         let temp_schema = init.add_encode::<Temperature>()?;
-        init.add_channel_with_id(TEMP_CHANNEL_ID, "/temperature")
+        temp_schema
+            .add_channel_with_id(TEMP_CHANNEL_ID, "/temperature")
             .expect("channel should be free")
-            .schema(&temp_schema)
             .message_count(temperature_count as u64);
 
         Ok(init.build())


### PR DESCRIPTION
### Changelog

Fix the ndjson data loader example so protobuf channels advertise the correct message encoding, and bump the example package version.

### Docs

None

### Description

The ndjson data loader creates protobuf schemas with `add_encode`, then registers fixed channel IDs for `/accelerometer` and `/temperature`.

With the current `foxglove_data_loader` API, calling `.schema(&linked_schema)` on a channel created from `InitializationBuilder` only sets the schema ID; it does not copy the schema's default message encoding. That left both channels with an empty `message_encoding`, which the app rejects as `Unsupported encoding`.

This changes the example to create the fixed-ID channels from each `LinkedSchema` instead. That preserves the explicit channel IDs while inheriting the protobuf message encoding from the encoded schema.

The example package version is also bumped from `1.1.0` to `1.2.0` so rebuilt packages are distinguishable from the previously broken extension artifact.

Validated the Rust loader locally with `cargo check --target wasm32-unknown-unknown`.

### Testing

- Package or locally install the ndjson data loader example from this branch.
- Load `examples/ndjson-data-loader/example.ndjson` in Foxglove.
- Confirm `/accelerometer` and `/temperature` load without `Unsupported encoding` errors.
