### PR TITLE
Use eval-source-map devtool in development for working breakpoints

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-foxglove-extension",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "publisher": "foxglove",
   "description": "Create and package Foxglove extensions",
   "license": "MIT",

--- a/src/webpackConfigExtension.ts
+++ b/src/webpackConfigExtension.ts
@@ -21,9 +21,15 @@ export default (
       libraryTarget: "commonjs2",
       clean: true,
     },
-    // Use inline source maps so the map is shipped with extension.js while avoiding eval-based
-    // frames that make runtime stack remapping less reliable.
-    devtool: "inline-source-map",
+    // In development, use eval-source-map so each module is wrapped in its own eval() with a
+    // per-module //# sourceURL marker. DevTools uses those markers as discrete script identities,
+    // which is what allows breakpoints to bind when Foxglove evals the bundle at runtime. With a
+    // single inline-source-map at the bottom of the bundle, every module collapses to one
+    // anonymous eval script and per-file breakpoints do not bind.
+    //
+    // In production, keep inline-source-map: terser strips per-module eval markers regardless,
+    // and a single inline map yields cleaner stack traces in error reports.
+    devtool: isDev ? "eval-source-map" : "inline-source-map",
     externals: {
       "@foxglove/extension": "@foxglove/extension",
     },


### PR DESCRIPTION
## Summary

- Restores DevTools breakpoint binding in extension code, which has been broken since v1.2.0 (#212)
- Mode-aware devtool: `eval-source-map` in development (per-module eval frames with `//# sourceURL` markers DevTools can bind against), `inline-source-map` in production (keeps the cleaner stack traces #212 wanted)
- One-line behavior change in `src/webpackConfigExtension.ts`; no test or template changes

## Background

PR #212 (v1.2.0) switched webpack `devtool` from `eval-source-map` to `inline-source-map` to make runtime stack traces cleaner. That change silently broke debugging:

- Foxglove `eval()`s the entire extension bundle at runtime
- With `inline-source-map`, the bundle has a single source map appended to the end of one anonymous eval script
- DevTools can list the original `.ts`/`.tsx` files but every module collapses to the same script identity, so breakpoints either don't bind or all fire from a single location
- With `eval-source-map`, each module is wrapped in its own `eval(...)` call with a `//# sourceURL=webpack:///./src/Foo.tsx` marker, which DevTools treats as a discrete script and breakpoints bind on a per-file basis

## Verification

Reproduced both behaviors against a fresh `create-foxglove-extension@1.3.1` scaffold (Foxglove desktop, dev-mode build):

**Before (inline-source-map):**
- `ExamplePanel.tsx` visible in Sources but as part of a merged bundle
- All `console.log` calls attributed to a single line (`index.ts:9`) regardless of which file they were in
- Breakpoints on `ExamplePanel.tsx` lines unbound (hollow), never paused

**After (eval-source-map):**
- Each `.ts`/`.tsx` appears as its own discrete script under `webpack:///./src/`
- `console.log` attribution shows correct file and line for each module
- Breakpoints bind (solid dot), execution pauses, call stack shows original source frames

## Test plan

- [x] Local `yarn build` succeeds; `yarn test` passes
- [ ] Scaffold a fresh extension with the new build, `npm run build`, manually copy `dist/` into the Foxglove extensions folder, fully relaunch Foxglove
- [x] Verify in DevTools Sources that each `.ts`/`.tsx` appears as a discrete `webpack:///./src/` script
- [x] Verify a line breakpoint in a `.tsx` file binds and pauses on hit
- [x] Verify production build (`npm run package`) still emits a single `//# sourceMappingURL=data:...` (unchanged from current behavior)